### PR TITLE
Fix initial reducer logic, avoid take() and drop()

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "pretest": "npm run lib",
-    "prelib": "mkdir -p lib && typings install",
+    "prelib": "mkdir -p lib",
     "lib": "tsc",
     "prepublish": "npm run lib"
   },
   "dependencies": {
-    "xstream": "6.x.x"
+    "xstream": "10.x"
   },
   "devDependencies": {
-    "typescript": "^2.0.2",
-    "typings": "^1.3.3"
+    "typescript": "^2.3.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,21 +51,16 @@ export default function storageify<Sources extends OnionSource, Sinks extends On
     // change initial reducer (first reducer) of component
     // to merge default state with stored state
     const childReducer$ = componentSinks.onion;
-    const initialReducer$ =
-      xs.combine(
-          storedData$,
-          childReducer$.take(1)
-        )
-        .map(([storedState, initialReducerChild]: [any, Reducer]) =>
-            prevState =>
-              ({...initialReducerChild(prevState), storedState})
-          );
-    // replace initial reducer
-    const parentReducer$ =
-      xs.merge(
-          initialReducer$,
-          childReducer$.drop(1)
-        );
+
+    const parentReducer$ = storedData$.map(storedData =>
+      childReducer$.startWith(function initialStorageReducer(prevState: any) {
+        if (prevState) {
+          return {...prevState, ...storedData};
+        } else {
+          return storedData;
+        }
+      })
+    ).flatten();
 
     const storage$ = state$.map(_options.serialize)
         .map(value => ({key: _options.key, value}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "tabSize": 2
   },
   "files": [
-    "src/index.ts",
-    "typings/index.d.ts"
+    "src/index.ts"
   ]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,0 @@
-{
-  "globalDependencies": {
-    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2"
-  }
-}


### PR DESCRIPTION
The previous take(1) / drop(1) solution was buggy in some situations and would cause a program behavior where a legitimate reducer is dropped. This commit fixes that by prepending a reducer, and this reducer will take previous state and blend it with state from storage.

It's easier to review this PR commit-by-commit.

Also, would be good to release this as a new version soon because I plan to use it in TodoMVC Cycle.js.