### PR TITLE
Fix logic when deserializing non-existent state from localStorage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ function serialize(state: any) {
   return JSON.stringify(state);
 }
 
-function deserialize(str: string) {
-  return JSON.parse(str) || {};
+function deserialize(str: string | null) {
+  return str === null ? void 0 : JSON.parse(str);
 }
 
 export default function storageify<Sources extends OnionSource, Sinks extends OnionSink>(
@@ -54,8 +54,10 @@ export default function storageify<Sources extends OnionSource, Sinks extends On
 
     const parentReducer$ = storedData$.map(storedData =>
       childReducer$.startWith(function initialStorageReducer(prevState: any) {
-        if (prevState) {
+        if (prevState && storedData) {
           return {...prevState, ...storedData};
+        } else if (prevState) {
+          return prevState;
         } else {
           return storedData;
         }


### PR DESCRIPTION
Reading from localStorage can return empty, i.e. null. If we got null, then we should not deserialize that as the empty object. We should deserialize it to undefined because Cycle onionify treats undefined as "no state" and is important for initializing state with defaults.

This is actually important for TodoMVC implemented in onionify and storageify.