### PR TITLE
Prevent storageify from overwriting the storage$

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export default function storageify<Sources extends OnionSource, Sinks extends On
     const sinks = {
       ...(componentSinks as any),
       onion: parentReducer$,
-      storage: storage$,
+      storage: xs.merge(storage$, componentSinks.storage || xs.never())
     };
     return sinks;
   };


### PR DESCRIPTION
The app may be using the local storage for other stuff, which is prevented because storageify overwrites it